### PR TITLE
Minor spelling fix: Github->GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Setup Instructions
 Contributing
 ------------
 
-Contributing is easy: fork this repository on Github, make your changes, and make a pull request.
+Contributing is easy: fork this repository on GitHub, make your changes, and make a pull request.
 
 ### Screenshots (& Configurations)
 

--- a/qtile/templates/base.html
+++ b/qtile/templates/base.html
@@ -63,7 +63,7 @@
                     </li>
                     <li><a href="http://docs.qtile.org/"><span class="fa fa-lg fa-fw fa-book"></span> Documentation</a></li>
                     <li><a href="https://github.com/qtile/qtile/issues"><span class="fa fa-lg fa-fw fa-bug"></span> Issues</a></li>
-                    <li><a href="https://github.com/qtile/qtile"><span class="fa fa-lg fa-fw fa-github"></span> Github</a></li>
+                    <li><a href="https://github.com/qtile/qtile"><span class="fa fa-lg fa-fw fa-github"></span> GitHub</a></li>
                 </ul>
 
                 <div class="navbar-right current-release">

--- a/qtile/templates/pages/download.html
+++ b/qtile/templates/pages/download.html
@@ -17,7 +17,7 @@
 {% block content %}
     <h2><span class="fa fa-fw fa-star"></span> Get the latest official version</h2>
     <p>Qtile v{{ settings.QTILE_VERSION }} was released on {{ settings.QTILE_RELEASE_DATE|date }}.</p>
-    <p>You can download it from Github:</p>
+    <p>You can download it from GitHub:</p>
     <p><a href="{{ settings.QTILE_DOWNLOAD }}">{{ settings.QTILE_DOWNLOAD }}</a></p>
 
     <div class="panel panel-default">
@@ -72,7 +72,7 @@
             <p>The development version will have the latest features, but may
                 also contain new bugs. Grab this version if you want to live
                 on the bleeding edge, or you plan on hacking on Qtile. You'll
-                probably want to keep an eye on <a href="https://github.com/qtile/qtile">Qtile on Github</a>
+                probably want to keep an eye on <a href="https://github.com/qtile/qtile">Qtile on GitHub</a>
                 and subscribe to <a href="https://groups.google.com/group/qtile-dev">qtile-dev</a>.</p>
             <p>If you want to <i>set it and forget it</i>, then the latest
                 official release is for you. You'll wait longer between updates,

--- a/qtile/templates/pages/videos.html
+++ b/qtile/templates/pages/videos.html
@@ -31,7 +31,7 @@
         </div>
         <div class="panel-body">
             <p>Did you give a talk about Qtile or make a screencast showing off your config?</p>
-            <p>Send a pull request to <a href="https://github.com/qtile/qtile.org">qtile.org on Github</a>,
+            <p>Send a pull request to <a href="https://github.com/qtile/qtile.org">qtile.org on GitHub</a>,
                 and we'll get it added!</p>
         </div>
     </div>


### PR DESCRIPTION
Hi,

GitHub is the correct, case-sensitive name of GitHub, not Github which is used extensively in this site. So in these commits I changed Github to GitHub.

Thanks for your time,
Brenton