### PR TITLE
Fixed typo "fo" -> "of" on Downloads page.

### DIFF
--- a/qtile/templates/pages/download.html
+++ b/qtile/templates/pages/download.html
@@ -36,7 +36,7 @@
     </div>
 
     <h2><span class="fa fa-fw fa-flask"></span> Get the latest development version</h2>
-    <p>If you want the latest and greatest version fo Qtile, you can fetch it
+    <p>If you want the latest and greatest version of Qtile, you can fetch it
         with <a href="http://git-scm.com/">Git</a>:</p>
     <pre>git clone https://github.com/qtile/qtile.git</pre>
     <p>You can also download <a href="https://github.com/qtile/qtile/zipball/master">a zipped archive</a>


### PR DESCRIPTION
Many people go straight to the Downloads page to get started. Best to fix typos there to leave a good impression.