### PR TITLE
Temporarily change link to the Documentation section on the website.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,7 +27,7 @@ sectionPagesMenu    = "main"
     [[menu.main]]
         identifier  = "docs"
         name        = "Documentation"
-        url         = "http://docs.qtile.org/"
+        url         = "https://qtile.readthedocs.io/en/stable/manual/faq.html"
         weight      = 4
 
     [[menu.main]]

--- a/config.toml
+++ b/config.toml
@@ -27,7 +27,7 @@ sectionPagesMenu    = "main"
     [[menu.main]]
         identifier  = "docs"
         name        = "Documentation"
-        url         = "https://qtile.readthedocs.io/en/stable/manual/faq.html"
+        url         = "https://qtile.readthedocs.io/en/stable/index.html"
         weight      = 4
 
     [[menu.main]]


### PR DESCRIPTION
Tons of people are asking on Reddit/IRC/Discord about the broken documentation. Since `docs.qtile.org` doesn't work for now, let's maybe change the link on the main website, unless the normal address is back.