### PR TITLE
rework make files

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -22,17 +22,12 @@ jobs:
         with:
           hugo-version: '0.111.3'
           extended: true
-      
-      - name: Tailwind CSS Typography plugin
-        working-directory: themes/qtail
-        run: npm install @tailwindcss/typography
-      
-      - name: Build Qtail
-        working-directory: themes/qtail
-        run: npm run build-qtail
+
+      - name: install build dependencies
+        run: make deps
 
       - name: Build
-        run: hugo --gc --minify
+        run: make
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
-all:
-	cd themes/qtail/
-	npm run build-qtail
-public:
+.PHONY: public
+public: qtail
 	hugo --gc --minify
+
+.PHONY: qtail
+qtail:
+	(cd themes/qtail/ && npm run build-qtail)
+
+deps:
+	(cd themes/qtail/ && npm install @tailwindcss/typography)
 
 clean:
 	rm -rf public resources themes/qtail/assets/style.css

--- a/themes/qtail/package-lock.json
+++ b/themes/qtail/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@tailwindcss/typography": "^0.5.2",
+        "@tailwindcss/typography": "^0.5.9",
         "tailwindcss": "^3.0.24"
       }
     },

--- a/themes/qtail/package.json
+++ b/themes/qtail/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@tailwindcss/typography": "^0.5.2",
+    "@tailwindcss/typography": "^0.5.9",
     "tailwindcss": "^3.0.24"
   }
 }


### PR DESCRIPTION
Let's not keep two copies of the build steps in both CI and in the Makefile. This moves everything to the makefile, fixes the makefile to actually work, and changes the CI to invoke make.

Also bump the versions of tailwindcss since we're here.