### PR TITLE
header: move docs link back to docs.qtile.org

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,7 +27,7 @@ sectionPagesMenu    = "main"
     [[menu.main]]
         identifier  = "docs"
         name        = "Documentation"
-        url         = "https://qtile.readthedocs.io/en/stable/index.html"
+        url         = "https://docs.qtile.org"
         weight      = 4
 
     [[menu.main]]


### PR DESCRIPTION
our domain-fu is all fixed now, so this works again.